### PR TITLE
Fix optional appsettings copy

### DIFF
--- a/BotCheckAvl/BotCheckAvl.csproj
+++ b/BotCheckAvl/BotCheckAvl.csproj
@@ -18,10 +18,10 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="appsettings.Development.json">
+    <None Include="appsettings.Development.json" Condition="Exists('appsettings.Development.json')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="appsettings.Production.json">
+    <None Include="appsettings.Production.json" Condition="Exists('appsettings.Production.json')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- ensure `.csproj` does not fail when optional config files are missing by
  using `Include` with `Condition` for environment-specific appsettings files

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550f38a568832ebe6228226378b9e4