### PR TITLE
Simplify host initialization

### DIFF
--- a/BotCheckAvl/BotCheckAvl.csproj
+++ b/BotCheckAvl/BotCheckAvl.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotCheckAvl/Program.cs
+++ b/BotCheckAvl/Program.cs
@@ -1,43 +1,28 @@
-﻿using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 class Program
 {
-    // Entry point with async Task Main
     public static async Task Main(string[] args)
     {
-        // Get environment name from environment variable (default: Production)
-        var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
-            ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
-            ?? "Production";
+        using IHost host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging((context, logging) =>
+            {
+                var logLevel = context.Configuration["AppSettings:LogLevel"];
+                logging.ClearProviders();
+                logging.AddConsole();
+                logging.SetMinimumLevel(ParseLogLevel(logLevel));
+            })
+            .Build();
 
-        // Build configuration
-        var configBuilder = new ConfigurationBuilder()
-            .SetBasePath(AppContext.BaseDirectory)
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: true)
-            .AddEnvironmentVariables();
+        var config = host.Services.GetRequiredService<IConfiguration>();
+        var logger = host.Services.GetRequiredService<ILogger<Program>>();
+        var env = host.Services.GetRequiredService<IHostEnvironment>();
 
-        var config = configBuilder.Build();
+        var featureXEnabled = config.GetValue<bool>("AppSettings:FeatureXEnabled");
 
-        // GetValue extension method is available for IConfigurationSection, not IConfiguration directly
-        var logLevel = config["AppSettings:LogLevel"];
-        var featureXEnabledRaw = config["AppSettings:FeatureXEnabled"];
-        var featureXEnabled = bool.TryParse(featureXEnabledRaw, out var parsed) && parsed;
-
-        // Setup logger
-        using var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder
-                .AddConsole()
-                .SetMinimumLevel(ParseLogLevel(logLevel));
-        });
-        var logger = loggerFactory.CreateLogger<Program>();
-
-        logger.LogInformation($"Environment: {environment}");
-        logger.LogInformation($"LogLevel: {logLevel}");
+        logger.LogInformation($"Environment: {env.EnvironmentName}");
         logger.LogInformation($"FeatureXEnabled: {featureXEnabled}");
 
         if (featureXEnabled)
@@ -45,21 +30,17 @@ class Program
         else
             logger.LogWarning("Feature X is disabled.");
 
-        await Task.CompletedTask;
+        await host.RunAsync();
     }
 
-    // Helper to parse log level from string
-    private static LogLevel ParseLogLevel(string? level)
+    private static LogLevel ParseLogLevel(string? level) => level?.ToLower() switch
     {
-        return level?.ToLower() switch
-        {
-            "trace" => LogLevel.Trace,
-            "debug" => LogLevel.Debug,
-            "information" => LogLevel.Information,
-            "warning" => LogLevel.Warning,
-            "error" => LogLevel.Error,
-            "critical" => LogLevel.Critical,
-            _ => LogLevel.Information
-        };
-    }
+        "trace" => LogLevel.Trace,
+        "debug" => LogLevel.Debug,
+        "information" => LogLevel.Information,
+        "warning" => LogLevel.Warning,
+        "error" => LogLevel.Error,
+        "critical" => LogLevel.Critical,
+        _ => LogLevel.Information
+    };
 }


### PR DESCRIPTION
## Summary
- switch to `Host.CreateDefaultBuilder` for configuration and environment
- use configuration to set minimum log level
- register `Microsoft.Extensions.Hosting` package

## Testing
- `dotnet build BotCheckAvl/BotCheckAvl.csproj -v:m` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856b6518334832e8bb8c07a15709e4a