### PR TITLE
Integrate Telegram bot service

### DIFF
--- a/BotCheckAvl/BotCheckAvl.csproj
+++ b/BotCheckAvl/BotCheckAvl.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+    <PackageReference Include="Telegram.Bot" Version="19.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotCheckAvl/Program.cs
+++ b/BotCheckAvl/Program.cs
@@ -15,6 +15,11 @@ class Program
                 logging.AddConsole();
                 logging.SetMinimumLevel(ParseLogLevel(logLevel));
             })
+            .ConfigureServices((context, services) =>
+            {
+                services.Configure<TgBotSettings>(context.Configuration.GetSection("TgBot"));
+                services.AddHostedService<TgBotService>();
+            })
             .Build();
 
         var config = host.Services.GetRequiredService<IConfiguration>();

--- a/BotCheckAvl/TgBotService.cs
+++ b/BotCheckAvl/TgBotService.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+
+public class TgBotService : BackgroundService
+{
+    private readonly ILogger<TgBotService> _logger;
+    private readonly TgBotSettings _settings;
+    private readonly TelegramBotClient _botClient;
+
+    public TgBotService(IOptions<TgBotSettings> options, ILogger<TgBotService> logger)
+    {
+        _settings = options.Value;
+        _logger = logger;
+        _botClient = new TelegramBotClient(_settings.Token);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("TgBotService is starting");
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Placeholder for bot logic. In a real bot, you'd handle updates here.
+            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+        }
+        _logger.LogInformation("TgBotService is stopping");
+    }
+}

--- a/BotCheckAvl/TgBotSettings.cs
+++ b/BotCheckAvl/TgBotSettings.cs
@@ -1,0 +1,7 @@
+using System;
+
+public class TgBotSettings
+{
+    public string Token { get; set; } = string.Empty;
+    public string? WebhookUrl { get; set; }
+}

--- a/BotCheckAvl/appsettings.json
+++ b/BotCheckAvl/appsettings.json
@@ -2,5 +2,9 @@
   "AppSettings": {
     "LogLevel": "Information",
     "FeatureXEnabled": false
+  },
+  "TgBot": {
+    "Token": "YOUR_TELEGRAM_BOT_TOKEN",
+    "WebhookUrl": null
   }
-} 
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ BotCheckAvl is a Telegram bot designed to monitor the availability and health of
 
 - All configuration (timeouts, retry counts, etc.) can be managed via the bot's interactive menu.
 - Service URLs and their statuses are stored and managed by the bot.
+- The `appsettings.json` file now includes a `TgBot` section. Set your Telegram bot token in `TgBot:Token` and optionally a `WebhookUrl`.
 
 ## Use Cases
 
@@ -29,7 +30,7 @@ BotCheckAvl is a Telegram bot designed to monitor the availability and health of
 
 ## Getting Started
 
-1. Clone the repository and configure your bot token and initial settings.
+1. Clone the repository and edit `appsettings.json` to provide your bot token in the `TgBot` section.
 2. Run the application using .NET 9.0.
 3. Interact with the bot in Telegram to add, remove, or manage services.
 


### PR DESCRIPTION
## Summary
- add `TgBotService` background service with options
- register bot service in `Program.cs`
- include Telegram bot settings in `appsettings.json`
- add Telegram package reference
- document new configuration

## Testing
- `dotnet build` *(fails: NETSDK1045, .NET 9.0 not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee4ec9cc832eb2a7e5afc653ee36