### PR TITLE
Add EF Core storage support

### DIFF
--- a/BotCheckAvl/BotCheckAvl.csproj
+++ b/BotCheckAvl/BotCheckAvl.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Telegram.Bot" Version="19.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24172.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.3.24172.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotCheckAvl/Data/BotDbContext.cs
+++ b/BotCheckAvl/Data/BotDbContext.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using System.Reflection;
+
+public class BotDbContext : DbContext
+{
+    public BotDbContext(DbContextOptions<BotDbContext> options) : base(options) { }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<MonitoredService> MonitoredServices => Set<MonitoredService>();
+    public DbSet<PingHistory> PingHistories => Set<PingHistory>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.TelegramUserId)
+            .IsUnique();
+    }
+}

--- a/BotCheckAvl/Models/MonitoredService.cs
+++ b/BotCheckAvl/Models/MonitoredService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+public class MonitoredService
+{
+    public int Id { get; set; }
+    public string Url { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; } = true;
+
+    public int UserId { get; set; }
+    public User? User { get; set; }
+
+    public ICollection<PingHistory> History { get; set; } = new List<PingHistory>();
+}

--- a/BotCheckAvl/Models/PingHistory.cs
+++ b/BotCheckAvl/Models/PingHistory.cs
@@ -1,0 +1,11 @@
+using System;
+
+public class PingHistory
+{
+    public int Id { get; set; }
+    public DateTime Timestamp { get; set; }
+    public bool IsUp { get; set; }
+
+    public int MonitoredServiceId { get; set; }
+    public MonitoredService? MonitoredService { get; set; }
+}

--- a/BotCheckAvl/Models/User.cs
+++ b/BotCheckAvl/Models/User.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+public class User
+{
+    public int Id { get; set; }
+    public long TelegramUserId { get; set; }
+    public string? Username { get; set; }
+
+    public ICollection<MonitoredService> Services { get; set; } = new List<MonitoredService>();
+}

--- a/BotCheckAvl/Program.cs
+++ b/BotCheckAvl/Program.cs
@@ -2,7 +2,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 using System.Reflection;
+
+// Local types (in project namespace-less files)
 
 class Program
 {
@@ -12,6 +15,9 @@ class Program
             .ConfigureServices((context, services) =>
             {
                 services.Configure<TgBotSettings>(context.Configuration.GetSection("TgBot"));
+                services.AddDbContext<BotDbContext>(options =>
+                    options.UseSqlite(context.Configuration.GetConnectionString("Default")));
+                services.AddTransient<MonitoringService>();
                 services.AddHostedService<TgBotService>();
             })
             .Build();

--- a/BotCheckAvl/Services/MonitoringService.cs
+++ b/BotCheckAvl/Services/MonitoringService.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BotCheckAvl.Services
+{
+    public class MonitoringService
+    {
+        private readonly BotDbContext _db;
+
+        public MonitoringService(BotDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<List<MonitoredService>> GetServicesAsync(long telegramUserId)
+        {
+            return await _db.MonitoredServices
+                .Include(m => m.User)
+                .Where(m => m.User.TelegramUserId == telegramUserId)
+                .ToListAsync();
+        }
+
+        public async Task<MonitoredService> AddServiceAsync(long telegramUserId, string url)
+        {
+            var user = await _db.Users.FirstOrDefaultAsync(u => u.TelegramUserId == telegramUserId);
+            if (user == null)
+            {
+                user = new User { TelegramUserId = telegramUserId };
+                _db.Users.Add(user);
+                await _db.SaveChangesAsync();
+            }
+
+            var svc = new MonitoredService { Url = url, UserId = user.Id, IsEnabled = true };
+            _db.MonitoredServices.Add(svc);
+            await _db.SaveChangesAsync();
+            return svc;
+        }
+
+        public async Task AddPingResultAsync(int serviceId, bool isUp)
+        {
+            var ping = new PingHistory
+            {
+                MonitoredServiceId = serviceId,
+                Timestamp = DateTime.UtcNow,
+                IsUp = isUp
+            };
+            _db.PingHistories.Add(ping);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<List<PingHistory>> GetHistoryAsync(int serviceId)
+        {
+            return await _db.PingHistories
+                .Where(p => p.MonitoredServiceId == serviceId)
+                .OrderByDescending(p => p.Timestamp)
+                .ToListAsync();
+        }
+    }
+}

--- a/BotCheckAvl/Services/TgBotService.cs
+++ b/BotCheckAvl/Services/TgBotService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using BotCheckAvl.Services;
 using Telegram.Bot;
 
 public class TgBotService : BackgroundService
@@ -8,11 +9,16 @@ public class TgBotService : BackgroundService
     private readonly ILogger<TgBotService> _logger;
     private readonly TgBotSettings _settings;
     private readonly TelegramBotClient _botClient;
+    private readonly MonitoringService _monitoringService;
 
-    public TgBotService(IOptions<TgBotSettings> options, ILogger<TgBotService> logger)
+    public TgBotService(
+        IOptions<TgBotSettings> options,
+        ILogger<TgBotService> logger,
+        MonitoringService monitoringService)
     {
         _settings = options.Value;
         _logger = logger;
+        _monitoringService = monitoringService;
         try
         {
             _botClient = new TelegramBotClient(_settings.Token);
@@ -29,7 +35,9 @@ public class TgBotService : BackgroundService
         _logger.LogInformation("TgBotService is starting");
         while (!stoppingToken.IsCancellationRequested)
         {
-            // Placeholder for bot logic. In a real bot, you'd handle updates here.
+            // Demo database access
+            var services = await _monitoringService.GetServicesAsync(0);
+            _logger.LogDebug($"Loaded {services.Count} services from DB");
             await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
         }
         _logger.LogInformation("TgBotService is stopping");

--- a/BotCheckAvl/appsettings.json
+++ b/BotCheckAvl/appsettings.json
@@ -6,5 +6,8 @@
   "TgBot": {
     "Token": "YOUR_TELEGRAM_BOT_TOKEN",
     "WebhookUrl": null
+  },
+  "ConnectionStrings": {
+    "Default": "Data Source=botcheckavl.db"
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ BotCheckAvl is a Telegram bot designed to monitor the availability and health of
 2. Run the application using .NET 9.0.
 3. Interact with the bot in Telegram to add, remove, or manage services.
 
+## Database Migrations
+
+Entity Framework Core with SQLite is used for data storage. After changing the
+model, create and apply migrations:
+
+```bash
+dotnet tool install --global dotnet-ef   # once
+dotnet ef migrations add InitialCreate
+dotnet ef database update
+```
+
+The default SQLite database file is `botcheckavl.db` as configured in
+`appsettings.json`.
+
 ---
 
 **Note:** This project is under active development. Contributions and feedback are welcome! 


### PR DESCRIPTION
## Summary
- install Entity Framework Core packages
- add `User`, `MonitoredService` and `PingHistory` models
- implement `BotDbContext` and register it in the app
- add a simple `MonitoringService` and update `TgBotService`
- update configuration with SQLite connection string
- document EF Core migrations in README

## Testing
- `dotnet restore BotCheckAvl/BotCheckAvl.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582e2db18c832e910e27c89a131a67