### PR TITLE
Refactor command handlers to use CommandResult

### DIFF
--- a/BotCheckAvl/Services/Commands/AddServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/AddServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class AddServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.AddService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "AddService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/BotCommand.cs
+++ b/BotCheckAvl/Services/Commands/BotCommand.cs
@@ -1,0 +1,13 @@
+namespace BotCheckAvl.Services.Commands
+{
+    public enum BotCommand
+    {
+        AddService,
+        DisableService,
+        EnableService,
+        DeleteService,
+        ShowService,
+        ShowAll,
+        CheckService
+    }
+}

--- a/BotCheckAvl/Services/Commands/CheckServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/CheckServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class CheckServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.CheckService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "CheckService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/CommandHandlerBase.cs
+++ b/BotCheckAvl/Services/Commands/CommandHandlerBase.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public abstract class CommandHandlerBase
+    {
+        public abstract BotCommand Command { get; }
+
+        public abstract Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments);
+    }
+}

--- a/BotCheckAvl/Services/Commands/CommandHandlerFactory.cs
+++ b/BotCheckAvl/Services/Commands/CommandHandlerFactory.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public static class CommandHandlerFactory
+    {
+        public static CommandHandlerBase Create(BotCommand command)
+        {
+            return command switch
+            {
+                BotCommand.AddService => new AddServiceHandler(),
+                BotCommand.DisableService => new DisableServiceHandler(),
+                BotCommand.EnableService => new EnableServiceHandler(),
+                BotCommand.DeleteService => new DeleteServiceHandler(),
+                BotCommand.ShowService => new ShowServiceHandler(),
+                BotCommand.ShowAll => new ShowAllHandler(),
+                BotCommand.CheckService => new CheckServiceHandler(),
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, null)
+            };
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/CommandResult.cs
+++ b/BotCheckAvl/Services/Commands/CommandResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class CommandResult
+    {
+        public bool IsSuccess { get; set; }
+        public List<string> Errors { get; } = new();
+        public List<string> Warnings { get; } = new();
+        public string? SuccessMessage { get; set; }
+    }
+}

--- a/BotCheckAvl/Services/Commands/DeleteServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/DeleteServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class DeleteServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.DeleteService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "DeleteService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/DisableServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/DisableServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class DisableServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.DisableService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "DisableService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/EnableServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/EnableServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class EnableServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.EnableService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "EnableService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/ShowAllHandler.cs
+++ b/BotCheckAvl/Services/Commands/ShowAllHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class ShowAllHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.ShowAll;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "ShowAll command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/BotCheckAvl/Services/Commands/ShowServiceHandler.cs
+++ b/BotCheckAvl/Services/Commands/ShowServiceHandler.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BotCheckAvl.Services.Commands
+{
+    public class ShowServiceHandler : CommandHandlerBase
+    {
+        public override BotCommand Command => BotCommand.ShowService;
+
+        public override Task<CommandResult> HandleCommand(CancellationToken ct, params string[] arguments)
+        {
+            var result = new CommandResult
+            {
+                IsSuccess = true,
+                SuccessMessage = "ShowService command received"
+            };
+            return Task.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CommandResult` type representing command execution outcome
- update `CommandHandlerBase` and stubs to return `CommandResult` from `HandleCommand`
- send bot response using the new result in `TgBotService`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adb1b7470832eb3b58298d3f4e810